### PR TITLE
Fix up cmake builds and workflow for windows including required sourc…

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -2,6 +2,10 @@ name: Windows
 
 on:
   workflow_dispatch:
+    inputs:
+      debugArchive:
+        type: boolean
+        description: Get a full debug archive even if failed.
   push:
     branches: [ master ]
   pull_request:
@@ -27,17 +31,57 @@ jobs:
           repository: rhasspy/espeak-ng
           path: espeak-ng
       - name: configure-espeak
-        run: cd espeak-ng && cmake -Bbuild -DUSE_ASYNC:BOOL=OFF -DBUILD_SHARED_LIBS:BOOL=${{ matrix.shlib }} -A ${{ matrix.arch }} -DUSE_MBROLA:BOOL=OFF -DUSE_LIBSONIC:BOOL=OFF -DUSE_LIBPCAUDIO:BOOL=OFF -DUSE_KLATT:BOOL=OFF -DUSE_SPEECHPLAYER:BOOL=OFF -DEXTRA_cmn:BOOL=ON -DEXTRA_ru:BOOL=ON
+        run: |
+             cd espeak-ng &&
+             cmake -Bbuild -DUSE_ASYNC:BOOL=OFF -DBUILD_SHARED_LIBS:BOOL=${{ matrix.shlib }} -A ${{ matrix.arch }} -DUSE_MBROLA:BOOL=OFF -DUSE_LIBSONIC:BOOL=OFF -DUSE_LIBPCAUDIO:BOOL=OFF -DUSE_KLATT:BOOL=OFF -DUSE_SPEECHPLAYER:BOOL=OFF -DEXTRA_cmn:BOOL=ON -DEXTRA_ru:BOOL=ON
       - name: make-espeak
-        run: cd espeak-ng && cmake --build build --config ${{ matrix.config }}
+        run: |
+             cd espeak-ng
+             cmake --build build --config ${{ matrix.config }}
       - name: install-espeak
-        run: cd espeak-ng && cmake --install build --prefix "$PWD"
+        run: |
+            cd espeak-ng
+            cmake --install build --prefix "${{ github.workspace }}/espeak-ng-install"
       - uses: actions/checkout@v3
         with:
           path: piper-phonemize
       - name: prepare-onnxruntime
-        run: curl -L -o onnxruntime.zip 'https://github.com/microsoft/onnxruntime/releases/download/v1.14.1/onnxruntime-win-x64-1.14.1.zip' && unzip onnxruntime.zip && mkdir -p piper-phonemize/lib/Windows-x86_64 && mv onnxruntime-* piper-phonemize/lib/Windows-x86_64/onnxruntime
+        run: |
+             cd piper-phonemize
+             curl -L -o onnxruntime.zip 'https://github.com/microsoft/onnxruntime/releases/download/v1.14.1/onnxruntime-win-x64-1.14.1.zip'
+             unzip onnxruntime.zip
+             mkdir -p lib/Windows-AMD64
+             mv onnxruntime-* lib/Windows-AMD64/onnxruntime
       - name: configure-piper
-        run: cd piper-phonemize && env:PKG_CONFIG_PATH="${PWD}/espeak-ng/lib/pkgconfig" && cmake -Bbuild
+        run: |
+             cd piper-phonemize
+             $env:ESPEAK_PREFIX_DIR = "${{ github.workspace }}/espeak-ng-install"
+             cmake -Bbuild  -DCMAKE_INSTALL_PREFIX=lib/Windows-AMD64
       - name: make-piper
-        run: cd piper-phonemize && cmake --build build --config ${{ matrix.config }}
+        run: |
+             cd piper-phonemize
+             cmake --build build --config ${{ matrix.config }}
+      - name: bundle-library
+        run: |
+             cd piper-phonemize
+             $env:CMAKE_INSTALL_BINDIR = "lib/Windows-AMD64/"   
+             cmake --install build
+      - name: bundle
+        run: |
+             cd piper-phonemize
+             mkdir -p lib/Windows-AMD64/espeak-ng/build
+             mv ${{ github.workspace }}/espeak-ng-install/lib lib/Windows-AMD64/espeak-ng/build
+             cp ${{ github.workspace }}/espeak-ng-install/bin/* lib/Windows-AMD64/espeak-ng/build/lib/
+             rm -r -fo build
+             rm -r -fo onnxruntime.zip
+      - name: Archive Files
+        uses: actions/upload-artifact@v2
+        with:
+          name: readyforwheel 
+          path: piper-phonemize/
+      - name: Debug Archive
+        uses: actions/upload-artifact@v2
+        if: always() && github.event.inputs.debugArchive == 'true'
+        with:
+          name: debug 
+          path: ./

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,17 +10,27 @@ project(
     LANGUAGES CXX
 )
 
-string(APPEND CMAKE_CXX_FLAGS " -Wall -Wextra -Wl,-rpath,'$ORIGIN'")
-string(APPEND CMAKE_C_FLAGS " -Wall -Wextra")
+if(MSVC)
+	set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS true)
+    string(APPEND CMAKE_CXX_FLAGS " /W4 /utf-8")
+    string(APPEND CMAKE_C_FLAGS " /W4 /utf-8")
+
+    find_library(ESPEAK_NG_LIBRARIES espeak-ng HINTS "$ENV{ESPEAK_PREFIX_DIR}/lib")
+	find_path(ESPEAK_NG_LIBRARY_DIRS NAMES espeak-ng.lib PATH_SUFFIXES lib HINTS "$ENV{ESPEAK_PREFIX_DIR}")
+    find_path(ESPEAK_NG_INCLUDE_DIRS NAMES espeak-ng/espeak_ng.h PATH_SUFFIXES include HINTS "$ENV{ESPEAK_PREFIX_DIR}")
+else()
+    string(APPEND CMAKE_CXX_FLAGS " -Wall -Wextra -Wl,-rpath,'$ORIGIN'")
+    string(APPEND CMAKE_C_FLAGS " -Wall -Wextra")
+
+    find_package(PkgConfig)
+    pkg_check_modules(ESPEAK_NG REQUIRED espeak-ng<2)
+endif()
 
 # lib/Linux-x86_64
 # lib/Linux-aarch64
 set(ONNXRUNTIME_ROOTDIR ${CMAKE_CURRENT_LIST_DIR}/lib/${CMAKE_HOST_SYSTEM_NAME}-${CMAKE_HOST_SYSTEM_PROCESSOR}/onnxruntime)
 
-# ---- espeak-ng ---
 
-find_package(PkgConfig)
-pkg_check_modules(ESPEAK_NG REQUIRED espeak-ng<2)
 
 # ---- Declare library ----
 
@@ -76,7 +86,8 @@ target_include_directories(
 
 target_link_directories(
     piper_phonemize_exe PUBLIC
-    ${ESPEAK_NG_LIBRARY_DIRS}
+    piper_phonemize
+	${ESPEAK_NG_LIBRARY_DIRS}
 )
 
 target_link_libraries(piper_phonemize_exe PUBLIC

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,9 @@ from setuptools import setup
 
 _DIR = Path(__file__).parent
 _ESPEAK_DIR = _DIR / "espeak-ng" / "build"
-_LIB_DIR = _DIR / "lib" / f"Linux-{platform.machine()}"
+_LIB_DIR = _DIR / "lib" / f"{platform.system()}-{platform.machine()}"
 _ONNXRUNTIME_DIR = _LIB_DIR / "onnxruntime"
+_PHONEMIZE_WIN_BUILD = _LIB_DIR / "piper_phonemize""
 
 __version__ = "1.2.0"
 
@@ -22,9 +23,9 @@ ext_modules = [
             "src/tashkeel.cpp",
         ],
         define_macros=[("VERSION_INFO", __version__)],
-        include_dirs=[str(_ESPEAK_DIR / "include"), str(_ONNXRUNTIME_DIR / "include")],
-        library_dirs=[str(_ESPEAK_DIR / "lib"), str(_ONNXRUNTIME_DIR / "lib")],
-        libraries=["espeak-ng", "onnxruntime"],
+        include_dirs=[str(_ESPEAK_DIR / "include"), str(_ONNXRUNTIME_DIR / "include"), str(_PHONEMIZE_WIN_BUILD, "include")],
+        library_dirs=[str(_ESPEAK_DIR / "lib"), str(_ONNXRUNTIME_DIR / "lib"), str(_PHONEMIZE_WIN_BUILD, "lib"), str(_PHONEMIZE_WIN_BUILD, "bin")],
+        libraries=["espeak-ng", "onnxruntime", "piper_phonemize"],
     ),
 ]
 

--- a/src/phoneme_ids.hpp
+++ b/src/phoneme_ids.hpp
@@ -7,6 +7,18 @@
 
 #include "phonemize.hpp"
 
+// Basically cmake export all symbols in windows still requires
+// explicit export of data symbols
+#if defined(_WIN32)
+  #ifdef piper_phonemize_EXPORTS
+    #define API_DATA __declspec(dllexport)
+  #else
+    #define API_DATA __declspec(dllimport)
+  #endif
+#else
+  #define API
+#endif
+
 namespace piper {
 
 typedef int64_t PhonemeId;
@@ -31,9 +43,9 @@ struct PhonemeIdConfig {
   std::shared_ptr<PhonemeIdMap> phonemeIdMap;
 };
 
-extern const size_t MAX_PHONEMES;
-extern PhonemeIdMap DEFAULT_PHONEME_ID_MAP;
-extern std::map<std::string, PhonemeIdMap> DEFAULT_ALPHABET;
+extern API_DATA const size_t MAX_PHONEMES;
+extern API_DATA PhonemeIdMap DEFAULT_PHONEME_ID_MAP;
+extern API_DATA std::map<std::string, PhonemeIdMap> DEFAULT_ALPHABET;
 
 void phonemes_to_ids(const std::vector<Phoneme> &phonemes,
                      PhonemeIdConfig &config,

--- a/src/tashkeel.cpp
+++ b/src/tashkeel.cpp
@@ -83,7 +83,14 @@ void tashkeel_load(std::string modelPath, State &state) {
                        instanceName.c_str());
   state.env.DisableTelemetryEvents();
   state.options.SetExecutionMode(ExecutionMode::ORT_PARALLEL);
-  state.onnx = Ort::Session(state.env, modelPath.c_str(), state.options);
+  #ifdef _WIN32  // This is defined for Windows
+    std::wstring wModelPath(modelPath.begin(), modelPath.end());
+    state.onnx = Ort::Session(state.env, wModelPath.c_str(), state.options);
+  #else  // This is for Linux
+    state.onnx = Ort::Session(state.env, modelPath.c_str(), state.options);
+  #endif
+
+  
 }
 
 std::string tashkeel_run(std::string text, State &state) {


### PR DESCRIPTION
Feel free to take this to get a boost in a working windows build.  These changes will get everything building and package the dynamic library along side the espeak and onnx in prep to deploy the dlls with the python package.  I cleaned up setup.py some as well to prep for getting the wheel to work.  There were also some minor source changes required to get this to compile with cmake and msvc and to get the exported symbols in the dll working.  The workflow will provide a readyforwheel.zip that has everything build you can use to see if you can build the python package or what additional changes are needed. 

The issue that was blocking your current changes was the use of package-config; this was using a version of the perl's strawberry gnu stack on the Windows GitHub workers and it has issues.  I wrote out its usage and provided explicit install prefixes espeak in the cmake file only for window builds.  I tried my best to not break anything linux related, but you'll need to test that theory.

Note that for the arch in Windows for cmake and python it will read as amd64, so I changed the expected lib path for deployment to follow the name.  I'm sure there is a way to clean up all the use of those paths in the workflow change I made I'm just not very proficient at the workflow file syntax and it's really tedious to test, so it might be a little messy but it works.

There are likely additional flags you want to add to piper-phonemize's build and other changes to polish this off.  I am probably at my limits, but I do hope you can take at least some of this in support of getting a windows piper build. 

