### PR TITLE
cmake: add ESPEAK_NG_VERSION

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,12 +99,14 @@ endif()
 
 if(NOT DEFINED ESPEAK_NG_DIR)
     set(ESPEAK_NG_DIR "${CMAKE_CURRENT_BINARY_DIR}/ei")
-
+    if(NOT DEFINED ESPEAK_NG_VERSION)
+        set(ESPEAK_NG_VERSION "refs/heads/master")
+    endif()
     include(ExternalProject)
     ExternalProject_Add(
         espeak_ng_external
         PREFIX "${CMAKE_CURRENT_BINARY_DIR}/e"
-        URL "https://github.com/rhasspy/espeak-ng/archive/refs/heads/master.zip"
+        URL "https://github.com/rhasspy/espeak-ng/archive/${ESPEAK_NG_VERSION}.zip"
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${ESPEAK_NG_DIR}
         CMAKE_ARGS -DUSE_ASYNC:BOOL=OFF
         CMAKE_ARGS -DBUILD_SHARED_LIBS:BOOL=ON


### PR DESCRIPTION
this allows to specify a custom espeak-ng version

See also:  https://github.com/mudler/LocalAI/issues/1356
Reasoning: https://github.com/rhasspy/espeak-ng/pull/1 broke building against espeak-ng, and would ease out things if we could pinpoint to specific versions so to gate changes at CI level

cc @synesthesiam 