### PR TITLE
cmake: Allow to build with system libraries and other improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,7 +223,7 @@ enable_testing()
 add_executable(test_piper_phonemize src/test.cpp src/phoneme_ids.cpp)
 add_test(
     NAME test_piper_phonemize
-    COMMAND test_piper_phonemize "${ESPEAK_NG_DIR}/share/espeak-ng-data" "${CMAKE_SOURCE_DIR}/etc/libtashkeel_model.ort"
+    COMMAND test_piper_phonemize "${ESPEAK_NG_DIR}/share/espeak-ng-data" "${piper_phonemize_SOURCE_DIR}/etc/libtashkeel_model.ort"
 )
 
 target_compile_features(test_piper_phonemize PUBLIC cxx_std_17)
@@ -266,7 +266,7 @@ install(
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 install(
-    DIRECTORY ${CMAKE_SOURCE_DIR}/src/
+    DIRECTORY ${piper_phonemize_SOURCE_DIR}/src/
     DESTINATION include/piper-phonemize
     FILES_MATCHING
     PATTERN "*.h"
@@ -277,7 +277,7 @@ install(
     ARCHIVE DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 install(
-    FILES ${CMAKE_SOURCE_DIR}/etc/libtashkeel_model.ort
+    FILES ${piper_phonemize_SOURCE_DIR}/etc/libtashkeel_model.ort
     DESTINATION ${CMAKE_INSTALL_DATADIR}/piper-phonemize)
 
 # Dependencies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,8 @@ project(
     LANGUAGES CXX
 )
 
+option(BUILD_EXTERNAL "Build external dependencies" OFF)
+
 if(MSVC)
     # Force compiler to use UTF-8 for IPA constants
     add_compile_options("$<$<C_COMPILER_ID:MSVC>:/utf-8>")
@@ -37,110 +39,133 @@ set_target_properties(piper_phonemize PROPERTIES
 # ---- onnxruntime ---
 
 # Look for onnxruntime files in <root>/lib
-if(NOT DEFINED ONNXRUNTIME_DIR)
-    if(NOT DEFINED ONNXRUNTIME_VERSION)
-        set(ONNXRUNTIME_VERSION "1.14.1")
-    endif()
+if (BUILD_EXTERNAL)
+    if(NOT DEFINED ONNXRUNTIME_DIR)
+        if(NOT DEFINED ONNXRUNTIME_VERSION)
+            set(ONNXRUNTIME_VERSION "1.14.1")
+        endif()
 
-    if(WIN32)
-        # Windows x86-64
-        set(ONNXRUNTIME_PREFIX "onnxruntime-win-x64-${ONNXRUNTIME_VERSION}")
-        set(ONNXRUNTIME_EXT "zip")
-    elseif (APPLE)
-        if(CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64)
-            # MacOS x86-64
-            set(ONNXRUNTIME_PREFIX "onnxruntime-osx-x86_64-${ONNXRUNTIME_VERSION}")
-        elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL arm64)
-            # MacOS Apple Silicon
-            set(ONNXRUNTIME_PREFIX "onnxruntime-osx-arm64-${ONNXRUNTIME_VERSION}")
+        if(WIN32)
+            # Windows x86-64
+            set(ONNXRUNTIME_PREFIX "onnxruntime-win-x64-${ONNXRUNTIME_VERSION}")
+            set(ONNXRUNTIME_EXT "zip")
+        elseif (APPLE)
+            if(CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64)
+                # MacOS x86-64
+                set(ONNXRUNTIME_PREFIX "onnxruntime-osx-x86_64-${ONNXRUNTIME_VERSION}")
+            elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL arm64)
+                # MacOS Apple Silicon
+                set(ONNXRUNTIME_PREFIX "onnxruntime-osx-arm64-${ONNXRUNTIME_VERSION}")
+            else()
+                message(FATAL_ERROR "Unsupported architecture for onnxruntime")
+            endif()
+
+            set(ONNXRUNTIME_EXT "tgz")
         else()
-            message(FATAL_ERROR "Unsupported architecture for onnxruntime")
+            if(CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64)
+                # Linux x86-64
+                set(ONNXRUNTIME_PREFIX "onnxruntime-linux-x64-${ONNXRUNTIME_VERSION}")
+            elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL aarch64)
+                # Linux ARM 64-bit
+                set(ONNXRUNTIME_PREFIX "onnxruntime-linux-aarch64-${ONNXRUNTIME_VERSION}")
+            elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL armv7l)
+                # Linux ARM 32-bit
+                set(ONNXRUNTIME_PREFIX "onnxruntime-linux-arm32-${ONNXRUNTIME_VERSION}")
+                set(ONNXRUNTIME_URL "https://github.com/synesthesiam/prebuilt-apps/releases/download/v1.0/onnxruntime-linux-arm32-${ONNXRUNTIME_VERSION}.tgz")
+            else()
+                message(FATAL_ERROR "Unsupported architecture for onnxruntime")
+            endif()
+
+            set(ONNXRUNTIME_EXT "tgz")
         endif()
 
-        set(ONNXRUNTIME_EXT "tgz")
-    else()
-        if(CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64)
-            # Linux x86-64
-            set(ONNXRUNTIME_PREFIX "onnxruntime-linux-x64-${ONNXRUNTIME_VERSION}")
-        elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL aarch64)
-            # Linux ARM 64-bit
-            set(ONNXRUNTIME_PREFIX "onnxruntime-linux-aarch64-${ONNXRUNTIME_VERSION}")
-        elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL armv7l)
-            # Linux ARM 32-bit
-            set(ONNXRUNTIME_PREFIX "onnxruntime-linux-arm32-${ONNXRUNTIME_VERSION}")
-            set(ONNXRUNTIME_URL "https://github.com/synesthesiam/prebuilt-apps/releases/download/v1.0/onnxruntime-linux-arm32-${ONNXRUNTIME_VERSION}.tgz")
-        else()
-            message(FATAL_ERROR "Unsupported architecture for onnxruntime")
+        if(NOT DEFINED ONNXRUNTIME_URL)
+            set(ONNXRUNTIME_URL "https://github.com/microsoft/onnxruntime/releases/download/v${ONNXRUNTIME_VERSION}/${ONNXRUNTIME_PREFIX}.${ONNXRUNTIME_EXT}")
         endif()
 
-        set(ONNXRUNTIME_EXT "tgz")
-    endif()
+        set(ONNXRUNTIME_FILENAME "${ONNXRUNTIME_PREFIX}.${ONNXRUNTIME_EXT}")
+        set(ONNXRUNTIME_DIR "${CMAKE_CURRENT_LIST_DIR}/lib/${ONNXRUNTIME_PREFIX}")
 
-    if(NOT DEFINED ONNXRUNTIME_URL)
-        set(ONNXRUNTIME_URL "https://github.com/microsoft/onnxruntime/releases/download/v${ONNXRUNTIME_VERSION}/${ONNXRUNTIME_PREFIX}.${ONNXRUNTIME_EXT}")
-    endif()
+        if(NOT EXISTS "${ONNXRUNTIME_DIR}")
+            if(NOT EXISTS "download/${ONNXRUNTIME_FILENAME}")
+                # Download onnxruntime release
+                message("Downloading ${ONNXRUNTIME_URL}")
+                file(DOWNLOAD "${ONNXRUNTIME_URL}" "download/${ONNXRUNTIME_FILENAME}")
+            endif()
 
-    set(ONNXRUNTIME_FILENAME "${ONNXRUNTIME_PREFIX}.${ONNXRUNTIME_EXT}")
-    set(ONNXRUNTIME_DIR "${CMAKE_CURRENT_LIST_DIR}/lib/${ONNXRUNTIME_PREFIX}")
-
-    if(NOT EXISTS "${ONNXRUNTIME_DIR}")
-        if(NOT EXISTS "download/${ONNXRUNTIME_FILENAME}")
-            # Download onnxruntime release
-            message("Downloading ${ONNXRUNTIME_URL}")
-            file(DOWNLOAD "${ONNXRUNTIME_URL}" "download/${ONNXRUNTIME_FILENAME}")
+            # Extract .zip or .tgz to a directory like lib/onnxruntime-linux-x64-1.14.1/
+            file(ARCHIVE_EXTRACT INPUT "download/${ONNXRUNTIME_FILENAME}" DESTINATION "${CMAKE_CURRENT_LIST_DIR}/lib")
         endif()
-
-        # Extract .zip or .tgz to a directory like lib/onnxruntime-linux-x64-1.14.1/
-        file(ARCHIVE_EXTRACT INPUT "download/${ONNXRUNTIME_FILENAME}" DESTINATION "${CMAKE_CURRENT_LIST_DIR}/lib")
     endif()
+else()
+    find_package(onnxruntime REQUIRED CONFIG)
 endif()
 
 # ---- espeak-ng ---
 
-if(NOT DEFINED ESPEAK_NG_DIR)
-    set(ESPEAK_NG_DIR "${CMAKE_CURRENT_BINARY_DIR}/ei")
+if (BUILD_EXTERNAL)
+    if(NOT DEFINED ESPEAK_NG_DIR)
+        set(ESPEAK_NG_DIR "${CMAKE_CURRENT_BINARY_DIR}/ei")
 
-    include(ExternalProject)
-    ExternalProject_Add(
-        espeak_ng_external
-        PREFIX "${CMAKE_CURRENT_BINARY_DIR}/e"
-        URL "https://github.com/rhasspy/espeak-ng/archive/0f65aa301e0d6bae5e172cc74197d32a6182200f.zip"
-        CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${ESPEAK_NG_DIR}
-        CMAKE_ARGS -DUSE_ASYNC:BOOL=OFF
-        CMAKE_ARGS -DBUILD_SHARED_LIBS:BOOL=ON
-        CMAKE_ARGS -DUSE_MBROLA:BOOL=OFF
-        CMAKE_ARGS -DUSE_LIBSONIC:BOOL=OFF
-        CMAKE_ARGS -DUSE_LIBPCAUDIO:BOOL=OFF
-        CMAKE_ARGS -DUSE_KLATT:BOOL=OFF
-        CMAKE_ARGS -DUSE_SPEECHPLAYER:BOOL=OFF
-        CMAKE_ARGS -DEXTRA_cmn:BOOL=ON
-        CMAKE_ARGS -DEXTRA_ru:BOOL=ON
-        CMAKE_ARGS -DCMAKE_C_FLAGS="-D_FILE_OFFSET_BITS=64"
-    )
-    add_dependencies(piper_phonemize espeak_ng_external)
+        include(ExternalProject)
+        ExternalProject_Add(
+            espeak_ng_external
+            PREFIX "${CMAKE_CURRENT_BINARY_DIR}/e"
+            URL "https://github.com/rhasspy/espeak-ng/archive/0f65aa301e0d6bae5e172cc74197d32a6182200f.zip"
+            CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${ESPEAK_NG_DIR}
+            CMAKE_ARGS -DUSE_ASYNC:BOOL=OFF
+            CMAKE_ARGS -DBUILD_SHARED_LIBS:BOOL=ON
+            CMAKE_ARGS -DUSE_MBROLA:BOOL=OFF
+            CMAKE_ARGS -DUSE_LIBSONIC:BOOL=OFF
+            CMAKE_ARGS -DUSE_LIBPCAUDIO:BOOL=OFF
+            CMAKE_ARGS -DUSE_KLATT:BOOL=OFF
+            CMAKE_ARGS -DUSE_SPEECHPLAYER:BOOL=OFF
+            CMAKE_ARGS -DEXTRA_cmn:BOOL=ON
+            CMAKE_ARGS -DEXTRA_ru:BOOL=ON
+            CMAKE_ARGS -DCMAKE_C_FLAGS="-D_FILE_OFFSET_BITS=64"
+        )
+        add_dependencies(piper_phonemize espeak_ng_external)
+    endif()
+else()
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(espeak_ng REQUIRED IMPORTED_TARGET espeak-ng)
 endif()
 
 
 # ---- Declare library ----
 
+add_library(piper::phonemize ALIAS piper_phonemize)
+
 target_include_directories(
     piper_phonemize PUBLIC
     "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>"
-    ${ESPEAK_NG_DIR}/include
-    ${ONNXRUNTIME_DIR}/include
 )
 
-target_link_directories(
-    piper_phonemize PUBLIC
-    ${ESPEAK_NG_DIR}/lib
-    ${ONNXRUNTIME_DIR}/lib
-)
+if (BUILD_EXTERNAL)
+    target_include_directories(
+        piper_phonemize PUBLIC
+        ${ESPEAK_NG_DIR}/include
+        ${ONNXRUNTIME_DIR}/include
+    )
 
-target_link_libraries(
-    piper_phonemize
-    espeak-ng
-    onnxruntime
-)
+    target_link_directories(
+        piper_phonemize PUBLIC
+        ${ESPEAK_NG_DIR}/lib
+        ${ONNXRUNTIME_DIR}/lib
+    )
+
+    target_link_libraries(
+        piper_phonemize
+        espeak-ng
+        onnxruntime
+    )
+else()
+    target_link_libraries(
+        piper_phonemize PRIVATE
+        PkgConfig::espeak_ng
+        onnxruntime::onnxruntime
+    )
+endif()
 
 target_compile_features(piper_phonemize PUBLIC cxx_std_17)
 
@@ -157,18 +182,31 @@ target_compile_features(piper_phonemize_exe PUBLIC cxx_std_17)
 target_include_directories(
     piper_phonemize_exe PUBLIC
     "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>"
-    ${ESPEAK_NG_DIR}/include
 )
 
-target_link_directories(
-    piper_phonemize_exe PUBLIC
-    ${ESPEAK_NG_DIR}/lib
-)
+if (BUILD_EXTERNAL)
+    target_include_directories(
+        piper_phonemize_exe PUBLIC
+        ${ESPEAK_NG_DIR}/include
+    )
 
-target_link_libraries(piper_phonemize_exe PUBLIC
-    piper_phonemize
-    espeak-ng
-)
+    target_link_directories(
+        piper_phonemize_exe PUBLIC
+        ${ESPEAK_NG_DIR}/lib
+    )
+
+    target_link_libraries(piper_phonemize_exe PUBLIC
+        piper_phonemize
+        espeak-ng
+    )
+else()
+    target_link_libraries(
+        piper_phonemize_exe PRIVATE
+        piper::phonemize
+        PkgConfig::espeak_ng
+        onnxruntime::onnxruntime
+    )
+endif()
 
 # ---- Declare test ----
 
@@ -185,18 +223,31 @@ target_compile_features(test_piper_phonemize PUBLIC cxx_std_17)
 target_include_directories(
     test_piper_phonemize PUBLIC
     "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>"
-    ${ESPEAK_NG_DIR}/include
 )
 
-target_link_directories(
-    test_piper_phonemize PUBLIC
-    ${ESPEAK_NG_DIR}/lib
-)
+if (BUILD_EXTERNAL)
+    target_include_directories(
+        test_piper_phonemize PUBLIC
+        ${ESPEAK_NG_DIR}/include
+    )
 
-target_link_libraries(test_piper_phonemize PUBLIC
-    piper_phonemize
-    espeak-ng
-)
+    target_link_directories(
+        test_piper_phonemize PUBLIC
+        ${ESPEAK_NG_DIR}/lib
+    )
+
+    target_link_libraries(test_piper_phonemize PUBLIC
+        piper_phonemize
+        espeak-ng
+    )
+else()
+    target_link_libraries(
+        test_piper_phonemize PRIVATE
+        piper::phonemize
+        onnxruntime::onnxruntime
+        PkgConfig::espeak_ng
+    )
+endif()
 
 # ---- Declare install targets ----
 
@@ -222,14 +273,16 @@ install(
     TYPE DATA)
 
 # Dependencies
-install(
-    DIRECTORY ${ESPEAK_NG_DIR}/
-    DESTINATION ${CMAKE_INSTALL_PREFIX})
+if (BUILD_EXTERNAL)
+    install(
+        DIRECTORY ${ESPEAK_NG_DIR}/
+        DESTINATION ${CMAKE_INSTALL_PREFIX})
 
-install(
-    DIRECTORY ${ONNXRUNTIME_DIR}/include/
-    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+    install(
+        DIRECTORY ${ONNXRUNTIME_DIR}/include/
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
-install(
-    DIRECTORY ${ONNXRUNTIME_DIR}/lib/
-    DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    install(
+        DIRECTORY ${ONNXRUNTIME_DIR}/lib/
+        DESTINATION ${CMAKE_INSTALL_LIBDIR})
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,7 +278,7 @@ install(
 
 install(
     FILES ${CMAKE_SOURCE_DIR}/etc/libtashkeel_model.ort
-    TYPE DATA)
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/piper-phonemize)
 
 # Dependencies
 if (BUILD_EXTERNAL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,10 +16,9 @@ if(MSVC)
     # Force compiler to use UTF-8 for IPA constants
     add_compile_options("$<$<C_COMPILER_ID:MSVC>:/utf-8>")
     add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
-
 elseif(NOT APPLE)
     # Linux flags
-    string(APPEND CMAKE_CXX_FLAGS " -Wall -Wextra -Wl,-rpath,'$ORIGIN'")
+    string(APPEND CMAKE_CXX_FLAGS " -Wall -Wextra")
     string(APPEND CMAKE_C_FLAGS " -Wall -Wextra")
 endif()
 
@@ -175,6 +174,15 @@ add_executable(piper_phonemize_exe src/main.cpp src/phoneme_ids.cpp)
 
 if(NOT WIN32)
     set_property(TARGET piper_phonemize_exe PROPERTY OUTPUT_NAME piper_phonemize)
+endif()
+
+if (APPLE)
+    set_target_properties(piper_phonemize_exe PROPERTIES
+        MACOSX_RPATH TRUE)
+elseif(NOT MSVC)
+    # Linux
+    set_target_properties(piper_phonemize_exe PROPERTIES
+        BUILD_RPATH_USE_ORIGIN TRUE)
 endif()
 
 target_compile_features(piper_phonemize_exe PUBLIC cxx_std_17)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,11 @@ project(
 
 option(BUILD_EXTERNAL "Build external dependencies" OFF)
 
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(piper_phonemize-config-version.cmake
+                                 VERSION ${piper_phonemize_VERSION}
+                                 COMPATIBILITY SameMajorVersion)
+
 if(MSVC)
     # Force compiler to use UTF-8 for IPA constants
     add_compile_options("$<$<C_COMPILER_ID:MSVC>:/utf-8>")
@@ -263,7 +268,11 @@ include(GNUInstallDirs)
 
 install(
     TARGETS piper_phonemize
+    EXPORT piper_phonemize-config
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+install(EXPORT piper_phonemize-config
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/piper_phonemize)
 
 install(
     DIRECTORY ${piper_phonemize_SOURCE_DIR}/src/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: clean
 
 all:
-	cmake -Bbuild -DCMAKE_INSTALL_PREFIX=install
+	cmake -Bbuild -DCMAKE_INSTALL_PREFIX="$${PREFIX:-install}" -DBUILD_EXTERNAL="$${BUILD_EXTERNAL:-ON}"
 	cmake --build build --config Release
 	cd build && ctest --config Release
 	cmake --install build


### PR DESCRIPTION
This patchset allows you to build piper-phonemize with system libraries instead of fetching sources from the internet. For this a new option has been introduced BUILD_EXTERNAL which will enable building with external sources. The default in cmake is OFF in the Makefile it is ON.

This also generates a cmake config file so you can consume the library using `find_package(piper_phonemize)` from other cmake files. It also fixes some issues if you use it as an external project.

You can see it building for openSUSE against system libraries here:

https://build.opensuse.org/package/show/home:gladiac/piper-phonemize